### PR TITLE
Increase the fall detection timer

### DIFF
--- a/MHWI_LLBG/MHWI_LLBG.ahk
+++ b/MHWI_LLBG/MHWI_LLBG.ahk
@@ -268,7 +268,7 @@ LLBG() {
 
             timeInState := QPC() - currentStateStartTime
 
-            if ((timeInState > 17)){
+            if ((timeInState > 34)){
                if (GetAmmoType()=GetAmmoID(PRIMARY_AMMO)){
                   SendKey([keyForward, keyReload])
                   AMMO_SCRIPT_Q := 0


### PR DESCRIPTION
The fall detection timer was a bit too sensitive, increased the amount of time you must be falling before script decides you are truly falling.